### PR TITLE
feat(order): implement cancel order feature

### DIFF
--- a/imports/plugins/core/accounts/client/components/ordersList.js
+++ b/imports/plugins/core/accounts/client/components/ordersList.js
@@ -13,11 +13,12 @@ class OrdersList extends Component {
   static propTypes = {
     allOrdersInfo: PropTypes.array,
     handleDisplayMedia: PropTypes.func,
-    isProfilePage: PropTypes.bool
+    isProfilePage: PropTypes.bool,
+    onCancelOrderClick: PropTypes.func
   }
 
   render() {
-    const { allOrdersInfo, handleDisplayMedia } = this.props;
+    const { allOrdersInfo, handleDisplayMedia, onCancelOrderClick } = this.props;
 
     if (allOrdersInfo) {
       return (
@@ -34,6 +35,7 @@ class OrdersList extends Component {
                 paymentMethods={order.paymentMethods}
                 productImages={order.productImages}
                 handleDisplayMedia={handleDisplayMedia}
+                onCancelOrderClick={onCancelOrderClick}
                 isProfilePage={this.props.isProfilePage}
               />
             );

--- a/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
+++ b/imports/plugins/core/accounts/client/containers/userOrdersListContainer.js
@@ -32,6 +32,27 @@ handlers.handleDisplayMedia = (item) => {
   return false;
 };
 
+handlers.onCancelOrderClick = (order) => {
+  Alerts.alert({
+    title: "Cancel Order",
+    type: "question",
+    text: "Are you sure you want to cancel this order?",
+    showCancelButton: true
+  }, (isConfirm) => {
+    if (isConfirm) {
+      Meteor.call("wallet/cancelOrder", order, (err, res) => {
+        if (res === 2) {
+          Alerts.toast("Sorry, guest cannot cancel order", "error");
+        } else if (res === 1) {
+          Alerts.toast("Order successfully cancelled. Your wallet has  been refunded", "success");
+        } else {
+          Alerts.toast("An error occured, please try again", "error");
+        }
+      });
+    }
+  });
+};
+
 function composer(props, onData) {
   // Get user order from props
   const orders = props.orders;

--- a/imports/plugins/core/checkout/client/components/cancelOrderButton.jsx
+++ b/imports/plugins/core/checkout/client/components/cancelOrderButton.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Components } from "@reactioncommerce/reaction-components";
+
+const CancelOrderButton = (props) => {
+  const { order, orderStatus, onCancelOrderClick } = props;
+  return (
+    <div>
+      {
+        (orderStatus === "new" || orderStatus === "coreOrderWorkflow/canceled") &&
+        <Components.Button
+          status="primary"
+          disabled={orderStatus === "coreOrderWorkflow/canceled"}
+          buttonType="submit"
+          onClick={() => { onCancelOrderClick(order); }}
+          bezelStyle="solid"
+          label={orderStatus === "coreOrderWorkflow/canceled" ? "Cancelled" : "Cancel Order"}
+        />
+      }
+    </div>
+  );
+};
+
+CancelOrderButton.propTypes = {
+  onCancelOrderClick: PropTypes.func.isRequired,
+  order: PropTypes.object.isRequired,
+  orderStatus: PropTypes.string.isRequired
+};
+
+export default CancelOrderButton;

--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -5,6 +5,7 @@ import CompletedShopOrders from "./completedShopOrders";
 import CompletedOrderPaymentMethod from "./completedOrderPaymentMethods";
 import CompletedOrderSummary from "./completedOrderSummary";
 import AddEmail from "./addEmail";
+import CancelOrderButton from "./cancelOrderButton";
 
 /**
  * @summary Displays a summary/information about the order the user has just completed
@@ -18,7 +19,8 @@ import AddEmail from "./addEmail";
  * @property {Booleam} isProfilePage - A boolean value that checks if current page is user profile page
  * @return {Node} React node containing the top-level component for displaying the completed order/receipt page
  */
-const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, handleDisplayMedia, isProfilePage }) => {
+const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, handleDisplayMedia, onCancelOrderClick, isProfilePage }) => {
+  const orderStatus = order.workflow.status;
   if (!order) {
     return (
       <Components.NotFound
@@ -48,7 +50,18 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
 
   return (
     <div className="container order-completed">
-      { headerText }
+      <div style={{ display: "flex", width: "100%" }}>
+        {headerText}
+        {(orderStatus === "new" || orderStatus === "coreOrderWorkflow/canceled") &&
+          <div style={{ marginLeft: "auto" }}>
+            <CancelOrderButton
+              order={order}
+              orderStatus={orderStatus}
+              onCancelOrderClick={onCancelOrderClick}
+            />
+          </div>
+        }
+      </div>
       <div className="order-details-main">
         <div className="order-details-content-title">
           <p><Components.Translation defaultValue="Your Items" i18nKey={"cartCompleted.yourItems"} /></p>
@@ -81,8 +94,8 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
                 return <div className="order-details-info-box" key={shipment._id}>
                   <div className="order-details-info-box-content">
                     <p>
-                      {shipment.address.fullName}<br/>
-                      {shipment.address.address1}<br/>
+                      {shipment.address.fullName}<br />
+                      {shipment.address.address1}<br />
                       {shipment.address.city}, {shipment.address.region} {shipment.address.postal} {shipment.address.country}
                     </p>
                   </div>
@@ -109,6 +122,7 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
 };
 
 CompletedOrder.propTypes = {
+  cancelOrder: PropTypes.func,
   handleDisplayMedia: PropTypes.func,
   isProfilePage: PropTypes.bool,
   order: PropTypes.object,

--- a/imports/plugins/core/checkout/client/containers/completedOrderContainer.js
+++ b/imports/plugins/core/checkout/client/containers/completedOrderContainer.js
@@ -33,6 +33,28 @@ handlers.handleDisplayMedia = (item) => {
   return false;
 };
 
+
+handlers.onCancelOrderClick = (order) => {
+  Alerts.alert({
+    title: "Cancel Order",
+    type: "question",
+    text: "Are you sure you want to cancel this order?",
+    showCancelButton: true
+  }, (isConfirm) => {
+    if (isConfirm) {
+      Meteor.call("wallet/cancelOrder", order, (err, res) => {
+        if (res === 2) {
+          Alerts.toast("Sorry, guest cannot cancel order", "error");
+        } else if (res === 1) {
+          Alerts.toast("Order successfully cancelled. Your wallet has  been refunded", "success");
+        } else {
+          Alerts.toast("An error occured, please try again", "error");
+        }
+      });
+    }
+  });
+};
+
 function composer(props, onData) {
   // The Cart subscription does not update when you delete the original record
   // but don't change parameters so we need to re-init that subscription here.

--- a/imports/plugins/included/wallet/client/checkout/components/walletCheckout.js
+++ b/imports/plugins/included/wallet/client/checkout/components/walletCheckout.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Components } from "@reactioncommerce/reaction-components";
 
 import roundToTwo from "../../helpers/roundToTwo";
 
@@ -26,12 +27,14 @@ class WalletCheckout extends Component {
     const { showBody } = this.state;
     return (
       <div className="panel panel-default wallet-checkout">
-        <button
-          className={`btn add-cart panel-heading wallet-checkout__toggle ${showBody ? "isOpen" : ""}`}
+        <Components.Button
+          status="secondary"
+          buttonType="submit"
           onClick={this.toggleBody}
-        >
-          <span id="btn-complete-order">Pay with wallet</span>
-        </button>
+          bezelStyle="solid"
+          style={{ fontSize: "18px", color: "white", backgroundColor: "orange" }}
+          label={"Pay with wallet"}
+        />
         {
           showBody &&
           <div className="panel-body">

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-tether": "^0.5.7",
     "react-textarea-autosize": "^5.0.7",
     "react-transition-group": "^2.2.1",
+    "recharts": "^1.0.0-beta.9",
     "recompose": "^0.24.0",
     "request": "^2.83.0",
     "shallowequal": "^1.0.2",


### PR DESCRIPTION
#### What does this PR do?
Implement cancel order feature
#### Description of Task to be completed?
- create cancelOrderButton component
- create and attach onCancelOrder method to button
- attach button component to orderList in profile
- attach button component to completedOrder
- implement cancelOrder feature
#### How should this be manually tested?
- Launch the app via [Reaction Commerce](https://elendil-rc-staging.herokuapp.com)
- Sign up or sign
- Buy a product
- Locate the cancel order button on the order confirmation page
OR
- Click on profile
- Locate and click on the cancel order button on the order list
#### Any background context you want to provide?
- Refund is done to via the user wallet, therefore guests (anonymous user) cannot get a refund
#### What are the relevant pivotal tracker stories?
#153740728
#### Screenshots (if appropriate)
<img width="1680" alt="screen shot 2018-02-05 at 3 19 19 pm" src="https://user-images.githubusercontent.com/8871565/35809120-07c7a320-0a88-11e8-8df4-fa90cfb49f0d.png">
<img width="1680" alt="screen shot 2018-02-05 at 3 19 30 pm" src="https://user-images.githubusercontent.com/8871565/35809130-0b9a35ee-0a88-11e8-80a7-9d88959a4232.png">
<img width="1680" alt="screen shot 2018-02-05 at 3 19 35 pm" src="https://user-images.githubusercontent.com/8871565/35809136-10949eea-0a88-11e8-9c85-cfd08a794d6f.png">
